### PR TITLE
Adds support for standard American paper sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 - Create PDF from Vue template
 - Automatic PDF Generation
 - Customizable Metadata
-- Supports (A1, A2, A3, A4, A5)
+- Supports (A1, A2, A3, A4, A5, Letter, Legal, Tabloid)
 - Support dynamic routes (Nuxt Generate)
 - Support dynamic titles (from <title> tag)
 - I18n support for specific languages

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ yarn add -D nuxt-pdf
 
 ## Usage
 
-- Add the class `.page` to your page to display when printing, for formatting, add classes: `.a1`, `.a2`, `.a3`, `.a4` or `.a5`
+- Add the class `.page` to your page to display when printing, for formatting, add classes: `.a1`, `.a2`, `.a3`, `.a4`, `.a5`, `.letter`, `.legal`, or `.tabloid`
 
 - Add `nuxt-pdf` to the `buildModules` section of your `nuxt.config.js` file:
 

--- a/lib/css/legal.css
+++ b/lib/css/legal.css
@@ -1,5 +1,5 @@
 @page {
-  format: Letter;
+  format: Legal;
   size: 8.5in 14in;
   margin: 0in 0in;
 }

--- a/lib/css/legal.css
+++ b/lib/css/legal.css
@@ -7,6 +7,6 @@
 @media print {
   .page {
     width: 8.5in !important;
-    height: 13.875in !important;
+    height: 13.97in !important;
   }
 }

--- a/lib/css/legal.css
+++ b/lib/css/legal.css
@@ -1,0 +1,12 @@
+@page {
+  format: Letter;
+  size: 8.5in 14in;
+  margin: 0in 0in;
+}
+
+@media print {
+  .page {
+    width: 8.5in !important;
+    height: 13.875in !important;
+  }
+}

--- a/lib/css/letter.css
+++ b/lib/css/letter.css
@@ -1,0 +1,12 @@
+@page {
+  format: Letter;
+  size: 8.5in 11in;
+  margin: 0in 0in;
+}
+
+@media print {
+  .page {
+    width: 8.5in !important;
+    height: 10.875in !important;
+  }
+}

--- a/lib/css/letter.css
+++ b/lib/css/letter.css
@@ -7,6 +7,6 @@
 @media print {
   .page {
     width: 8.5in !important;
-    height: 10.875in !important;
+    height: 10.97in !important;
   }
 }

--- a/lib/css/tabloid.css
+++ b/lib/css/tabloid.css
@@ -1,5 +1,5 @@
 @page {
-  format: Letter;
+  format: Tabloid;
   size: 11in 17in;
   margin: 0in 0in;
 }

--- a/lib/css/tabloid.css
+++ b/lib/css/tabloid.css
@@ -7,6 +7,6 @@
 @media print {
   .page {
     width: 11in !important;
-    height: 16.875in !important;
+    height: 16.97in !important;
   }
 }

--- a/lib/css/tabloid.css
+++ b/lib/css/tabloid.css
@@ -1,0 +1,12 @@
+@page {
+  format: Letter;
+  size: 11in 17in;
+  margin: 0in 0in;
+}
+
+@media print {
+  .page {
+    width: 11in !important;
+    height: 16.875in !important;
+  }
+}

--- a/lib/module.js
+++ b/lib/module.js
@@ -8,7 +8,7 @@ const puppeteer = require('puppeteer')
 
 const defaults = require('./module.defaults')
 
-const supportedFormats = ['a1', 'a2', 'a3', 'a4', 'a5']
+const supportedFormats = ['a1', 'a2', 'a3', 'a4', 'a5', 'letter', 'legal', 'tabloid']
 
 module.exports = async function PDF(moduleOptions) {
   // const isSSG =


### PR DESCRIPTION
Please bear with me, this is my first PR in public repo... any suggestions welcome.

This attempts to add support for common paper sizes used in the U.S.
Tested lightly using `yarn link` locally in the project I'm hoping to use this on. 

Cuts pages a bit short as is done with other existing sizes, converted to inch format. 