### PR TITLE
Number of changes so a target:static with lots of generated pdf routes will work

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,16 @@ You can see the available options in the example [configuration](#configuration)
       // Change the format of the pdfs.
       format: "A4", // This is optional 
       printBackground: true // Include background in pdf.
+    }
+
+    /*
+    * Function options for page.setViewport([options])
+    * Read more: https://pptr.dev/#?product=Puppeteer&version=v2.0.0&show=api-pagesetviewportviewport
+    */
+    viewport: {
+      // override the default viewport
+      width: 1280,
+      height: 800
     },
 
     /*
@@ -135,7 +145,16 @@ You can see the available options in the example [configuration](#configuration)
         // Override global meta with individual meta for each pdf.
         meta: {
           title: "Home"
-        }
+        },
+        pdf: {
+          // route specific pdf options
+          landscape: true // Include background in pdf.
+        },
+        viewport: {
+          // route specific viewport
+          width: 1280,
+          height: 800
+        },
       },
       {
         // Output: static/downloads/documentation-vue.pdf

--- a/README.md
+++ b/README.md
@@ -83,8 +83,7 @@ You can see the available options in the example [configuration](#configuration)
     */
     pdf: {
       // Change the format of the pdfs.
-      format: "A4",
-
+      format: "A4", // This is optional 
       printBackground: true // Include background in pdf.
     },
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,9 @@ You can see the available options in the example [configuration](#configuration)
         // Route to content that should be converted into pdf.
         route: "docs",
 
+        // Default option is to remove the route after generation so it is not accessible
+        keep: true, // defaults to false
+
         // Specifify language for pdf. (Only when i18n is enabled!)
         locale: 'da'
 

--- a/lib/module.js
+++ b/lib/module.js
@@ -38,14 +38,11 @@ export const promisifyRoute = function promisifyRoute(fn, ...args) {
   return promise
 }
 
+async function timeout(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
 module.exports = async function PDF(moduleOptions) {
-  // const isSSG =
-  //   this.options.dev === false &&
-  //   (this.options.target === 'static' ||
-  //     this.options._generate ||
-  //     this.options.mode === 'spa')
-  const isGenerate = !!this.options._generate
-  const isDev = this.options.dev
 
   const options = Object.assign({}, defaults, moduleOptions, this.options.pdf)
 
@@ -170,68 +167,51 @@ module.exports = async function PDF(moduleOptions) {
     return uri
   }
 
-  async function build() {
+  async function build(buildArgs) {
+
     var nuxt
     var listener
-    if (!isDev && !isGenerate) {
-      console.log('Starting nuxt instance')
-      const {
-        loadNuxt
-      } = require('nuxt')
+    try {
+      if (buildArgs.generated) {
+        console.log('nuxt-pdf: Starting nuxt instance')
+        const {
+          loadNuxt
+        } = require('nuxt')
+        nuxt = await loadNuxt('start')
+        listener = await nuxt.server.listen()
+      }
 
-      nuxt = await loadNuxt('start')
-
-      listener = await nuxt.server.listen()
+      if (nuxt && 'url' in listener) {
+        url = listener.url
+      }
+    } catch (e) {
+      console.error("nuxt-pdf: Unable to start nuxt instance.  Be sure to run 'npm run build first'")
     }
-
-    if (nuxt && 'url' in listener) {
-      url = listener.url
-    }
-
-    let browser = await puppeteer.launch(
-      Object.assign({
-        headless: true
-      }, options.puppeteer)
-    )
-
-    let page = (await browser.pages())[0]
 
     const routes = await promisifyRoute(options.routes || [])
 
     for (let i = 0; i < routes.length; i++) {
       const route = routes[i]
-      console.log(chalk.cyan('↻') + ' Generating PDF at ' + route.route)
+      console.log(chalk.cyan('↻') + ` Generating PDF ${i+1}:${routes.length} at route ` + route.route)
 
       try {
         // Merge route meta with defaults from config.
         const meta = Object.assign({}, options.meta, route.meta)
 
-        page.goto(getUrl(route.route, route.locale))
-
-        await page.waitForSelector(
-          '#__nuxt',
-          nuxt ? {
-            visible: true,
-            timeout: 500
-          } : {
-            visible: true
-          }
+        let browser = await puppeteer.launch(
+          Object.assign({
+            headless: true
+          }, options.puppeteer)
         )
-
-        await page.reload()
-
-        await page.waitForSelector(
-          '#__nuxt',
-          nuxt ? {
-            visible: true,
-            timeout: 500
-          } : {
-            visible: true
-          }
-        )
+        let page = await browser.newPage();
+        await page.goto(`${url.replace(/\/$/, "")}${route.route}`, {
+          waitUntil: 'networkidle2'
+        });
 
         // Generate pdf based on dom content. (result by bytes)
-        const bytes = await page.pdf(Object.assign({}, options.pdf))
+        const bytes = await page.pdf(Object.assign({}, {
+          ...options.pdf
+        }))
 
         // Load bytes into pdf document, used for manipulating meta of file.
         const document = await Document.load(bytes)
@@ -251,7 +231,7 @@ module.exports = async function PDF(moduleOptions) {
         document.setCreationDate(meta.creationDate || new Date())
         document.setKeywords(meta.keywords || [])
 
-        const file = path.resolve(options.dir, route.file)
+        const file = path.resolve(buildArgs.generated ? 'dist' : options.dir, route.file)
 
         // Create folder where file will be stored.
         fs.mkdirSync(file.substring(0, file.lastIndexOf('/')), {
@@ -262,55 +242,46 @@ module.exports = async function PDF(moduleOptions) {
         const ws = fs.createWriteStream(file)
         ws.write(await document.save())
         ws.end()
+        console.log(`${chalk.green('✔')}  Generated PDF ${i+1}:${routes.length} at file ' ${route.file} (${document.getTitle()})`);
+        if (buildArgs.generated) {
+          await fs.unlinkSync(`./dist${route.route}/index.html`)
+          console.log(`${chalk.green('✔')}  Removed route index file used for PDF at ${route.route}`);
+          await fs.rmdirSync(`./dist${route.route}`)
+          console.log(`${chalk.green('✔')}  Removed route directory used for PDF at ${route.route}`);
+        }
+        await page.close();
+        await browser.close()
 
-        console.log(
-          chalk.green('✔') +
-          ' Generated PDF at ' +
-          route.path +
-          ` (${document.getTitle()})`
-        )
       } catch (e) {
-        console.log(
-          chalk.red('𐄂') +
-          ' Failed to generated PDF at ' +
-          route.route +
-          ` error: ${e.message}`
-        )
+        console.log(`${chalk.red('𐄂')} Failed to generated PDF ${i+1}:${routes.length} at route ${route.route} error: ${e.message}`);
       }
     }
 
-    browser.close()
-
-    browser = null;
-    page = null;
 
     if (nuxt) {
       await listener.close()
-
-      nuxt = null;
-      listener = null;
-      //delete nuxt
-      //delete listener
     }
   }
 
-  if (isDev) {
+  if (process.env.NODE_ENV !== "production") {
     this.nuxt.hook('build:compiled', async ({
       name
     }) => {
       if (name !== 'server') return
-
-      await build()
-    })
-  } else if (this.options._generate) {
-    this.nuxt.hook('generate:done', async () => {
-      await build()
+      await build({
+        generated: false
+      })
     })
   } else {
-    this.nuxt.hook('build:done', async () => {
-      await build()
+    this.nuxt.hook('generate:done', async ({
+      builder
+    }) => {
+      await build({
+        generated: true
+      })
     })
   }
+
 }
 
 module.exports.meta = require('../package.json')

--- a/lib/module.js
+++ b/lib/module.js
@@ -203,14 +203,22 @@ module.exports = async function PDF(moduleOptions) {
             headless: true
           }, options.puppeteer)
         )
+
         let page = await browser.newPage();
         await page.goto(`${url.replace(/\/$/, "")}${route.route}`, {
           waitUntil: 'networkidle2'
         });
 
+        if (options.viewport || route.viewport) {
+          page.setViewport(Object.assign({}, {
+            ...options.viewport,
+            ...route.viewport
+          }));
+        }
         // Generate pdf based on dom content. (result by bytes)
         const bytes = await page.pdf(Object.assign({}, {
-          ...options.pdf
+          ...options.pdf,
+          ...route.pdf
         }))
 
         // Load bytes into pdf document, used for manipulating meta of file.

--- a/lib/module.js
+++ b/lib/module.js
@@ -184,7 +184,7 @@ module.exports = async function PDF(moduleOptions) {
 
       url = listener.url;
     } catch (e) {
-      console.error("nuxt-pdf: Unable to start nuxt instance.  Be sure to run 'npm run build first'", e)
+      console.error("nuxt-pdf: If this is part of npm run generate be sure to run 'npm run build first'")
     }
 
     const routes = await promisifyRoute(options.routes || [])
@@ -241,7 +241,7 @@ module.exports = async function PDF(moduleOptions) {
         const ws = fs.createWriteStream(file)
         ws.write(await document.save())
         ws.end()
-        console.log(`${chalk.green('✔')}  Generated PDF ${i+1}:${routes.length} at file ' ${route.file} (${document.getTitle()})`);
+        console.log(`${chalk.green('✔')}  Generated PDF ${i+1}:${routes.length} at file '${file} (${document.getTitle()})`);
         if (buildArgs.generated) {
           await fs.unlinkSync(`./dist${route.route}/index.html`)
           console.log(`${chalk.green('✔')}  Removed route index file used for PDF at ${route.route}`);

--- a/lib/module.js
+++ b/lib/module.js
@@ -174,18 +174,17 @@ module.exports = async function PDF(moduleOptions) {
     try {
       if (buildArgs.generated) {
         console.log('nuxt-pdf: Starting nuxt instance')
+        let nuxt = require.resolve("nuxt-edge") ? 'nuxt-edge' : 'nuxt';
         const {
           loadNuxt
-        } = require('nuxt')
+        } = require(nuxt);
         nuxt = await loadNuxt('start')
         listener = await nuxt.server.listen()
       }
 
-      if (nuxt && 'url' in listener) {
-        url = listener.url
-      }
+      url = listener.url;
     } catch (e) {
-      console.error("nuxt-pdf: Unable to start nuxt instance.  Be sure to run 'npm run build first'")
+      console.error("nuxt-pdf: Unable to start nuxt instance.  Be sure to run 'npm run build first'", e)
     }
 
     const routes = await promisifyRoute(options.routes || [])

--- a/lib/module.js
+++ b/lib/module.js
@@ -78,19 +78,20 @@ module.exports = async function PDF(moduleOptions) {
    */
   this.options.css.push(path.resolve(__dirname, 'css/pdf.css'))
 
-  const format = options.pdf.format.toLowerCase()
+  if (options.pdf.format) {
+    const format = options.pdf.format.toLowerCase()
 
-  if (supportedFormats.includes(format)) {
-    this.options.css.push(path.resolve(__dirname, 'css/' + format + '.css'))
-  } else {
-    console.error(
-      chalk.bgRed.black(' ERROR ') +
-      " Unable to find format ('" +
-      options.pdf.format +
-      "')"
-    )
-
-    return
+    if (supportedFormats.includes(format)) {
+      this.options.css.push(path.resolve(__dirname, 'css/' + format + '.css'))
+    } else {
+      console.error(
+        chalk.bgRed.black(' ERROR ') +
+        " Unable to find format ('" +
+        options.pdf.format +
+        "')"
+      )
+      return
+    }
   }
 
   this.nuxt.hook('listen', (_, router) => (url = router.url.toString()))

--- a/lib/module.js
+++ b/lib/module.js
@@ -1,7 +1,9 @@
 const fs = require('fs')
 const path = require('path')
 
-const { PDFDocument: Document } = require('pdf-lib')
+const {
+  PDFDocument: Document
+} = require('pdf-lib')
 
 const chalk = require('chalk')
 const puppeteer = require('puppeteer')
@@ -9,6 +11,32 @@ const puppeteer = require('puppeteer')
 const defaults = require('./module.defaults')
 
 const supportedFormats = ['a1', 'a2', 'a3', 'a4', 'a5', 'letter', 'legal', 'tabloid']
+
+export const promisifyRoute = function promisifyRoute(fn, ...args) {
+  // If routes is an array
+  if (Array.isArray(fn)) {
+    return Promise.resolve(fn)
+  }
+  // If routes is a function expecting a callback
+  if (fn.length === arguments.length) {
+    return new Promise((resolve, reject) => {
+      fn((err, routeParams) => {
+        if (err) {
+          reject(err)
+        }
+        resolve(routeParams)
+      }, ...args)
+    })
+  }
+  let promise = fn(...args)
+  if (
+    !promise ||
+    (!(promise instanceof Promise) && typeof promise.then !== 'function')
+  ) {
+    promise = Promise.resolve(promise)
+  }
+  return promise
+}
 
 module.exports = async function PDF(moduleOptions) {
   // const isSSG =
@@ -28,8 +56,7 @@ module.exports = async function PDF(moduleOptions) {
   }
 
   if (i18n.enabled) {
-    i18n.options = Object.assign(
-      {},
+    i18n.options = Object.assign({},
       this.options.i18n,
       (this.options.modules.find(
         x => Array.isArray(x) && x[0] === 'nuxt-i18n'
@@ -55,14 +82,15 @@ module.exports = async function PDF(moduleOptions) {
   this.options.css.push(path.resolve(__dirname, 'css/pdf.css'))
 
   const format = options.pdf.format.toLowerCase()
+
   if (supportedFormats.includes(format)) {
     this.options.css.push(path.resolve(__dirname, 'css/' + format + '.css'))
   } else {
     console.error(
       chalk.bgRed.black(' ERROR ') +
-        " Unable to find format ('" +
-        options.pdf.format +
-        "')"
+      " Unable to find format ('" +
+      options.pdf.format +
+      "')"
     )
 
     return
@@ -77,8 +105,11 @@ module.exports = async function PDF(moduleOptions) {
    * Extending the generated routes with pdf requested routes.
    */
   this.nuxt.hook('generate:extendRoutes', async routes => {
-    for (let i = 0; i < options.routes.length; i++) {
-      const route = options.routes[i]
+
+    const generatedRoutes = await promisifyRoute(options.routes || [])
+
+    for (let i = 0; i < generatedRoutes.length; i++) {
+      const route = generatedRoutes[i]
 
       if (routes.filter(r => r.route === route.route).length > 0) {
         continue
@@ -92,9 +123,15 @@ module.exports = async function PDF(moduleOptions) {
   })
 
   const getUrl = (path, locale) => {
+
     const chunk = routeMap.find(
       route => route.path == path.split('?')[0].split('#')[0]
     )
+
+    //if (chunk === undefined && path != '/*/') {
+    //  return getUrl('/*/', locale)
+    //}
+
     if (chunk === undefined)
       throw new Error(
         'Unable to find route at ' + path.split('?')[0].split('#')[0]
@@ -109,9 +146,9 @@ module.exports = async function PDF(moduleOptions) {
       const routesNameSeparator = i18n.options.routesNameSeparator || '___'
       const route = routes.find(
         route =>
-          route.name.endsWith(
-            routesNameSeparator + locale + routesNameSeparator + 'default'
-          ) || route.name.endsWith(routesNameSeparator + locale)
+        route.name.endsWith(
+          routesNameSeparator + locale + routesNameSeparator + 'default'
+        ) || route.name.endsWith(routesNameSeparator + locale)
       )
 
       if (i18n.options.differentDomains) {
@@ -130,7 +167,6 @@ module.exports = async function PDF(moduleOptions) {
     } else {
       uri = url.replace(/\/$/, '') + path
     }
-
     return uri
   }
 
@@ -139,7 +175,9 @@ module.exports = async function PDF(moduleOptions) {
     var listener
     if (!isDev && !isGenerate) {
       console.log('Starting nuxt instance')
-      const { loadNuxt } = require('nuxt')
+      const {
+        loadNuxt
+      } = require('nuxt')
 
       nuxt = await loadNuxt('start')
 
@@ -150,15 +188,18 @@ module.exports = async function PDF(moduleOptions) {
       url = listener.url
     }
 
-    const browser = await puppeteer.launch(
-      Object.assign({ headless: true }, options.puppeteer)
+    let browser = await puppeteer.launch(
+      Object.assign({
+        headless: true
+      }, options.puppeteer)
     )
 
-    const page = (await browser.pages())[0]
+    let page = (await browser.pages())[0]
 
-    for (let i = 0; i < options.routes.length; i++) {
-      const route = options.routes[i]
+    const routes = await promisifyRoute(options.routes || [])
 
+    for (let i = 0; i < routes.length; i++) {
+      const route = routes[i]
       console.log(chalk.cyan('↻') + ' Generating PDF at ' + route.route)
 
       try {
@@ -169,22 +210,24 @@ module.exports = async function PDF(moduleOptions) {
 
         await page.waitForSelector(
           '#__nuxt',
-          nuxt
-            ? { visible: true, timeout: 500 }
-            : {
-                visible: true
-              }
+          nuxt ? {
+            visible: true,
+            timeout: 500
+          } : {
+            visible: true
+          }
         )
 
         await page.reload()
 
         await page.waitForSelector(
           '#__nuxt',
-          nuxt
-            ? { visible: true, timeout: 500 }
-            : {
-                visible: true
-              }
+          nuxt ? {
+            visible: true,
+            timeout: 500
+          } : {
+            visible: true
+          }
         )
 
         // Generate pdf based on dom content. (result by bytes)
@@ -222,35 +265,39 @@ module.exports = async function PDF(moduleOptions) {
 
         console.log(
           chalk.green('✔') +
-            ' Generated PDF at ' +
-            route.route +
-            ` (${document.getTitle()})`
+          ' Generated PDF at ' +
+          route.path +
+          ` (${document.getTitle()})`
         )
       } catch (e) {
         console.log(
           chalk.red('𐄂') +
-            ' Failed to generated PDF at ' +
-            route.route +
-            ` error: ${e.message}`
+          ' Failed to generated PDF at ' +
+          route.route +
+          ` error: ${e.message}`
         )
       }
     }
 
     browser.close()
 
-    delete browser
-    delete page
+    browser = null;
+    page = null;
 
     if (nuxt) {
       await listener.close()
 
-      delete nuxt
-      delete listener
+      nuxt = null;
+      listener = null;
+      //delete nuxt
+      //delete listener
     }
   }
 
   if (isDev) {
-    this.nuxt.hook('build:compiled', async ({ name }) => {
+    this.nuxt.hook('build:compiled', async ({
+      name
+    }) => {
       if (name !== 'server') return
 
       await build()

--- a/lib/module.js
+++ b/lib/module.js
@@ -210,6 +210,10 @@ module.exports = async function PDF(moduleOptions) {
         });
 
         if (options.viewport || route.viewport) {
+          console.log("setting viewport", Object.assign({}, {
+            ...options.viewport,
+            ...route.viewport
+          }))
           page.setViewport(Object.assign({}, {
             ...options.viewport,
             ...route.viewport
@@ -251,7 +255,7 @@ module.exports = async function PDF(moduleOptions) {
         ws.write(await document.save())
         ws.end()
         console.log(`${chalk.green('✔')}  Generated PDF ${i+1}:${routes.length} at file '${file} (${document.getTitle()})`);
-        if (buildArgs.generated) {
+        if (buildArgs.generated && !route.keep) {
           await fs.unlinkSync(`./dist${route.route}/index.html`)
           console.log(`${chalk.green('✔')}  Removed route index file used for PDF at ${route.route}`);
           await fs.rmdirSync(`./dist${route.route}`)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-pdf",
-  "version": "1.4.1",
+  "version": "2.0.0",
   "description": "NuxtJS module to generate PDF files and manage PDF in your Nuxt application",
   "repository": "https://github.com/ch99q/nuxt-pdf",
   "homepage": "https://github.com/ch99q/nuxt-pdf",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-pdf",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "NuxtJS module to generate PDF files and manage PDF in your Nuxt application",
   "repository": "https://github.com/ch99q/nuxt-pdf",
   "homepage": "https://github.com/ch99q/nuxt-pdf",


### PR DESCRIPTION
1. Promisify Routes : Allow for promise in addition to an array of routes
2. Prod nuxt generate and clean up generated routes - Delete routes that were used for generating pdfs
3. remove confusing isDev and generate options 
4. remove waits until __nuxt appear in DOM and rely on networkidle2 puppeteer option instead so images load
5. Really should consider removing height in stylesheets as it forces a single page PDF. For now you can override like 

`  @page {
    format: Letter;
    size: auto !important;
    margin: 0in 0in;
  }

  @media print {
    .page {
      width: 8.5in !important;
      height: auto !important;
    }
  }`
